### PR TITLE
mpassi options files

### DIFF
--- a/configuration/scripts/options/set_env.mpassi
+++ b/configuration/scripts/options/set_env.mpassi
@@ -1,0 +1,6 @@
+setenv NICELYR   7         # number of vertical layers in the ice
+setenv NSNWLYR   5         # number of vertical layers in the snow
+setenv TRSNOW    0         # set to 1 for advanced snow physics tracers
+
+
+

--- a/configuration/scripts/options/set_nml.mpassi
+++ b/configuration/scripts/options/set_nml.mpassi
@@ -1,5 +1,3 @@
-    dt             = 3600.0
-    tr_snow        = .false.
     rsnw_tmax      = 1500.0
     kcatbound      = 0
     emissivity     = 0.95

--- a/configuration/scripts/options/set_nml.mpassi
+++ b/configuration/scripts/options/set_nml.mpassi
@@ -1,0 +1,6 @@
+    dt             = 3600.0
+    tr_snow        = .false.
+    rsnw_tmax      = 1500.0
+    kcatbound      = 0
+    emissivity     = 0.95
+    oceanmixed_ice = .false.


### PR DESCRIPTION
- [x] Short (1 sentence) summary of your PR: 
    Namelist and environment options for Icepack runs configured similarly to MPAS-SI single-column.
- [x] Developer(s): 
    @eclare108213 @njeffery @dabail10
- [x] Suggest PR reviewers from list in the column to the right.
- [ ] Please copy the PR test results link or provide a summary of testing completed below.
    ENTER INFORMATION HERE 
- How much do the PR code changes differ from the unmodified code?   NA
    - [ ] bit for bit
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [x] No
- Does this PR add any new test cases?
    - [x] Yes
    - [ ] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [ ] Yes
    - [x] No, does the documentation need to be updated at a later time?
        - [x] Yes, possibly
        - [ ] No 
- [x] Please provide any additional information or relevant details below:

Specifies namelist settings and the number of ice and snow layers, as agreed on for comparison runs between Icepack and MPAS-SI.  In particular (some of these values are already set as defaults in icepack_in):

- 7 ice layers (NICELYR)
- 5 snow layers (NSNWLYR)
- 5 ice thickness categories (NCAT)
- old ice thickness category boundaries, not round numbers (kcatbound=0)
- remap ice thickness distribution, not delta function (kitd=1)
- snow tracers are turned off, for now (tr_snow=.false.)
- dry snow grain radius = 1500 (rsnw_tmax)
- emissivity = 0.95
- ocean mixed layer is turned off (oceanmixed=.false.)

Variations on these tests can be created by turning on or adding other options files.

Example command for a test with snicar-ad off:
`./icepack.setup -m conda --env macos --case nmlst0 -s mpassi`

Example command for a test with snicar-ad on:
`./icepack.setup -m conda --env macos --case nmlst1 -s mpassi,snicar`

This PR is a draft until we decide on the final, default configuration, which might also require changes to forcing, etc.