### PR TITLE
Minor updates consistent with E3SM columnphysics modifications

### DIFF
--- a/columnphysics/icepack_brine.F90
+++ b/columnphysics/icepack_brine.F90
@@ -66,13 +66,13 @@
                                       hbr_old,  hin,hsn,  firstice    )
 
       real (kind=dbl_kind), intent(in) :: &
-         aicen       , & ! concentration of ice
-         vicen       , & ! volume per unit area of ice          (m)
-         vsnon       , & ! volume per unit area of snow         (m)
-         meltb       , & ! bottom ice melt                      (m)
-         meltt       , & ! top ice melt                         (m)
-         congel      , & ! bottom ice growth                    (m)
-         snoice          ! top ice growth from flooding         (m)
+         aicen        , & ! concentration of ice
+         vicen        , & ! volume per unit area of ice          (m)
+         vsnon        , & ! volume per unit area of snow         (m)
+         meltb        , & ! bottom ice melt                      (m)
+         meltt        , & ! top ice melt                         (m)
+         congel       , & ! bottom ice growth                    (m)
+         snoice           ! top ice growth from flooding         (m)
 
       real (kind=dbl_kind), intent(out) :: &
          hbr_old          ! old brine height (m)
@@ -152,22 +152,20 @@
          nblyr           ! number of bio layers
 
       real (kind=dbl_kind), dimension (nblyr+2), intent(in) :: &
-         bgrid              ! biology nondimensional vertical grid points
+         bgrid           ! biology nondimensional vertical grid points
 
       real (kind=dbl_kind), dimension (nblyr+1), intent(in) :: &
-         igrid              ! biology vertical interface points
+         igrid           ! biology vertical interface points
 
       real (kind=dbl_kind), dimension (nilyr+1), intent(in) :: &
-         cgrid              ! CICE vertical coordinate
+         cgrid           ! CICE vertical coordinate
 
-      real (kind=dbl_kind), &
-         intent(in) :: &
+      real (kind=dbl_kind), intent(in) :: &
          hice_old    , & ! previous timestep ice height (m)
          sss         , & ! ocean salinity (ppt)
          sst             ! ocean temperature (C)
 
-      real (kind=dbl_kind), dimension(ntrcr), &
-         intent(in) :: &
+      real (kind=dbl_kind), dimension(ntrcr), intent(in) :: &
          trcrn
 
       real (kind=dbl_kind), intent(out) :: &
@@ -175,22 +173,19 @@
          bphi_min        ! surface porosity
 
       real (kind=dbl_kind), intent(inout) :: &
-         hbr_old           ! previous timestep brine height (m)
+         hbr_old         ! previous timestep brine height (m)
 
-      real (kind=dbl_kind), dimension (nblyr+1), &
-         intent(inout)  :: &
-         iDin           ! tracer diffusivity/h^2 (1/s) includes gravity drainage/molecular
+      real (kind=dbl_kind), dimension (nblyr+1), intent(inout)  :: &
+         iDin            ! tracer diffusivity/h^2 (1/s) includes gravity drainage/molecular
 
-      real (kind=dbl_kind), dimension (nblyr+1), &
-         intent(inout)  :: &
+      real (kind=dbl_kind), dimension (nblyr+1), intent(inout)  :: &
          iphin       , & ! porosity on the igrid
          ibrine_rho  , & ! brine rho on interface
          ibrine_sal  , & ! brine sal on interface
          iTin            ! Temperature on the igrid (oC)
 
-      real (kind=dbl_kind), dimension (nblyr+2), &
-         intent(inout)  :: &
-         bSin        , &    ! bulk salinity (ppt) on bgrid
+      real (kind=dbl_kind), dimension (nblyr+2), intent(inout)  :: &
+         bSin        , & ! bulk salinity (ppt) on bgrid
          brine_sal   , & ! equilibrium brine salinity (ppt)
          brine_rho       ! internal brine density (kg/m^3)
 
@@ -311,16 +306,14 @@
                                  i_grid,     sss)
 
       integer (kind=int_kind), intent(in) :: &
-         nblyr           ! number of bio layers
+         nblyr          ! number of bio layers
 
-      real (kind=dbl_kind), dimension (:), &
-         intent(in) :: &
-         bSin      , & ! salinity of ice layers on bio grid (ppt)
-         bTin      , & ! temperature of ice layers on bio grid for history (C)
-         i_grid        ! biology grid interface points
+      real (kind=dbl_kind), dimension (:), intent(in) :: &
+         bSin       , & ! salinity of ice layers on bio grid (ppt)
+         bTin       , & ! temperature of ice layers on bio grid for history (C)
+         i_grid         ! biology grid interface points
 
-      real (kind=dbl_kind), dimension (:), &
-         intent(inout) :: &
+      real (kind=dbl_kind), dimension (:), intent(inout) :: &
          brine_sal  , & ! equilibrium brine salinity (ppt)
          brine_rho  , & ! internal brine density (kg/m^3)
          ibrine_rho , & ! brine density on interface (kg/m^3)
@@ -342,14 +335,14 @@
       ! local variables
 
       real (kind=dbl_kind), dimension(nblyr+1) :: &
-          kin       !  permeability
+          kin           !  permeability
 
       real (kind=dbl_kind) :: &
           k_min, ktemp, &
           igrp, igrm, rigr  ! grid finite differences
 
       integer (kind=int_kind) :: &
-           k   ! layer index
+           k            ! layer index
 
       character(len=*),parameter :: subname='(prepare_hbrine)'
 
@@ -479,7 +472,7 @@
       ! local variables
 
       real (kind=dbl_kind) :: &
-         hbrmin    , & ! thinS or hin
+         hbrmin     , & ! thinS or hin
          dhbr_hin   , & ! hbr-hin
          hbrocn     , & ! brine height above sea level (m) hbr-h_ocn
          dhbr       , & ! change in brine surface
@@ -587,18 +580,18 @@
                                    ibrine_sal, sice_rho, sloss)
 
       integer (kind=int_kind), intent(in) :: &
-         n_cat       , & ! ice category
-         nilyr       , & ! number of ice layers
-         nblyr           ! number of bio layers
+         n_cat         , & ! ice category
+         nilyr         , & ! number of ice layers
+         nblyr             ! number of bio layers
 
       real (kind=dbl_kind), dimension (nblyr+2), intent(in) :: &
-         bgrid              ! biology nondimensional vertical grid points
+         bgrid             ! biology nondimensional vertical grid points
 
       real (kind=dbl_kind), dimension (nblyr+1), intent(in) :: &
-         igrid              ! biology vertical interface points
+         igrid             ! biology vertical interface points
 
       real (kind=dbl_kind), dimension (nilyr+1), intent(in) :: &
-         cgrid              ! CICE vertical coordinate
+         cgrid             ! CICE vertical coordinate
 
       real (kind=dbl_kind), intent(in) :: &
          hice_old      , & ! previous timestep ice height (m)
@@ -807,22 +800,22 @@
                                  brine_rho, ibrine_rho, drho)
 
       integer (kind=int_kind), intent(in) :: &
-         nblyr          ! number of bio layers
+         nblyr        ! number of bio layers
 
       real (kind=dbl_kind), dimension (nblyr+2), intent(in) :: &
-         b_grid         ! biology nondimensional grid layer points
+         b_grid       ! biology nondimensional grid layer points
 
       real (kind=dbl_kind), dimension (nblyr+1), intent(in) :: &
-         i_grid         ! biology grid interface points
+         i_grid       ! biology grid interface points
 
       real (kind=dbl_kind), dimension (nblyr+2), intent(in) :: &
-         brine_rho     ! Internal brine density (kg/m^3)
+         brine_rho    ! Internal brine density (kg/m^3)
 
       real (kind=dbl_kind), dimension (nblyr + 1), intent(in) :: &
-         ibrine_rho    ! Internal brine density (kg/m^3)
+         ibrine_rho   ! Internal brine density (kg/m^3)
 
       real (kind=dbl_kind), dimension (nblyr+1), intent(out) :: &
-         drho          ! brine difference about grid point (kg/m^3)
+         drho         ! brine difference about grid point (kg/m^3)
 
       ! local variables
 
@@ -921,7 +914,7 @@
          nblyr    ! number of bio layers
 
       real (kind=dbl_kind), intent(inout) :: &
-         phi_snow           !porosity at the ice-snow interface
+         phi_snow           ! porosity at the ice-snow interface
 
       real (kind=dbl_kind), dimension (nblyr+2), intent(out) :: &
          bgrid              ! biology nondimensional vertical grid points
@@ -930,9 +923,9 @@
          igrid              ! biology vertical interface points
 
       real (kind=dbl_kind), dimension (nilyr+1), intent(out) :: &
-         cgrid            , &  ! CICE vertical coordinate
-         icgrid           , &  ! interface grid for CICE (shortwave variable)
-         swgrid                ! grid for ice tracers used in dEdd scheme
+         cgrid         , &  ! CICE vertical coordinate
+         icgrid        , &  ! interface grid for CICE (shortwave variable)
+         swgrid             ! grid for ice tracers used in dEdd scheme
 
 !autodocument_end
 
@@ -1013,10 +1006,10 @@
                Rayleigh_real, trcrn_bgc, nt_bgc_S, ncat, sss)
 
       integer (kind=int_kind), intent(in) :: &
-       nblyr, & ! number of biolayers
+       nblyr  , & ! number of biolayers
        ntrcr_o, & ! number of non bio tracers
-       ncat , & ! number of categories
-       nt_bgc_S ! zsalinity index
+       ncat   , & ! number of categories
+       nt_bgc_S   ! zsalinity index
 
       logical (kind=log_kind), intent(inout) :: &
        Rayleigh_criteria
@@ -1028,7 +1021,7 @@
        sss
 
       real (kind=dbl_kind), dimension(:,:), intent(inout):: &
-       trcrn_bgc ! bgc subset of trcrn
+       trcrn_bgc  ! bgc subset of trcrn
 
 !autodocument_end
 

--- a/columnphysics/icepack_brine.F90
+++ b/columnphysics/icepack_brine.F90
@@ -292,7 +292,7 @@
 
       do k= 2, nblyr+1
          ikin(k) = k_o*iphin(k)**exp_h
-         iDin(k) = iphin(k)*Dm/hbr_old**2
+         if (hbr_old .GT. puny) iDin(k) = iphin(k)*Dm/hbr_old**2
          if (hbr_old .GE. Ra_c) &
             iDin(k) = iDin(k) &
                     + l_sk*ikin(k)*gravit/viscos_dynamic*drho(k)/hbr_old**2

--- a/columnphysics/icepack_itd.F90
+++ b/columnphysics/icepack_itd.F90
@@ -33,9 +33,9 @@
       use icepack_tracers,    only: nt_apnd, nt_hpnd, nt_fbri, tr_brine, nt_bgc_S, bio_index
       use icepack_tracers,    only: n_iso, tr_iso, tr_snow, nt_smice, nt_rsnw, nt_rhos
       use icepack_tracers,    only: icepack_compute_tracers
-      use icepack_parameters, only: solve_zsal, skl_bgc, z_tracers
+      use icepack_parameters, only: solve_zsal, skl_bgc, z_tracers, hi_min
       use icepack_parameters, only: kcatbound, kitd
-      use icepack_therm_shared, only: Tmin, hi_min
+      use icepack_therm_shared, only: Tmin
       use icepack_warnings,   only: warnstr, icepack_warnings_add
       use icepack_warnings,   only: icepack_warnings_setabort, icepack_warnings_aborted
       use icepack_zbgc_shared,only: zap_small_bgc
@@ -1815,9 +1815,6 @@
       b2 = c3         ! thickness for which participation function is small (m)
       b3 = max(rncat*(rncat-1), c2*b2/b1)
 
-      hi_min = p01    ! minimum ice thickness allowed (m) for thermo
-                      ! note hi_min is reset to 0.1 for kitd=0, below
-
       !-----------------------------------------------------------------
       ! Choose category boundaries based on one of four options.
       !
@@ -1869,9 +1866,6 @@
             hin_max(0) = c0     ! minimum ice thickness, m
          else
             ! delta function itd category limits
-#ifndef CESMCOUPLED
-            hi_min = p1    ! minimum ice thickness allowed (m) for thermo
-#endif
             cc1 = max(1.1_dbl_kind/rncat,hi_min)
             cc2 = c25*cc1
             cc3 = 2.25_dbl_kind
@@ -1927,6 +1921,10 @@
          enddo
 
       endif ! kcatbound
+
+      if (kitd == 1) then
+         hin_max(ncat) = 999.9_dbl_kind ! arbitrary big number
+      endif
 
       end subroutine icepack_init_itd
 

--- a/columnphysics/icepack_meltpond_cesm.F90
+++ b/columnphysics/icepack_meltpond_cesm.F90
@@ -18,6 +18,7 @@
       use icepack_kinds
       use icepack_parameters, only: c0, c1, c2, p01, puny
       use icepack_parameters, only: rhofresh, rhoi, rhos, Timelt, pndaspect, use_smliq_pnd
+      use icepack_parameters, only: hi_min
       use icepack_warnings, only: warnstr, icepack_warnings_add
       use icepack_warnings, only: icepack_warnings_setabort, icepack_warnings_aborted
 
@@ -32,7 +33,7 @@
 
 !=======================================================================
 
-      subroutine compute_ponds_cesm(dt,    hi_min,       &
+      subroutine compute_ponds_cesm(dt,                  &
                                     rfrac, meltt,        &
                                     melts, frain,        &
                                     aicen, vicen,        &
@@ -40,8 +41,7 @@
                                     meltsliqn)
 
       real (kind=dbl_kind), intent(in) :: &
-         dt,       & ! time step (s)
-         hi_min      ! minimum ice thickness allowed for thermo (m)
+         dt           ! time step (s)
 
       real (kind=dbl_kind), intent(in) :: &
          meltsliqn, & ! liquid input from snow liquid tracer

--- a/columnphysics/icepack_orbital.F90
+++ b/columnphysics/icepack_orbital.F90
@@ -68,8 +68,8 @@
       log_print = .false.   ! if true, write out orbital parameters
 
 #ifndef CESMCOUPLED
-      call shr_orb_params( iyear_AD, eccen , obliq , mvelp    , &
-                           obliqr  , lambm0, mvelpp, log_print)
+      call icepack_orb_params( iyear_AD, eccen , obliq , mvelp    , &
+                               obliqr  , lambm0, mvelpp, log_print)
       if (icepack_warnings_aborted(subname)) return
 #endif
 
@@ -117,8 +117,8 @@
       log_print = .false.   ! if true, write out orbital parameters
 
 #ifndef CESMCOUPLED
-      call shr_orb_params( iyear_AD, eccen , obliq , mvelp    , &
-                           obliqr  , lambm0, mvelpp, log_print)
+      call icepack_orb_params( iyear_AD, eccen , obliq , mvelp    , &
+                               obliqr  , lambm0, mvelpp, log_print)
       if (icepack_warnings_aborted(subname)) return
 #endif
 
@@ -190,28 +190,27 @@
 
       !--- update coszen when nextsw_cday valid
       if (ydayp1 > -0.5_dbl_kind) then
+         call shr_orb_decl(ydayp1, eccen, mvelpp, lambm0, &
+                           obliqr, decln, eccf)
+         coszen = sin(tlat)*sin(decln) &
+                + cos(tlat)*cos(decln) &
+                *cos((sec/secday-p5)*c2*pi + tlon) !cos(hour angle)
+      endif
 #else
       ydayp1 = yday + sec/secday
-#endif
-
-      call shr_orb_decl(ydayp1, eccen, mvelpp, lambm0, &
-                        obliqr, decln, eccf)
+      call icepack_orb_decl(ydayp1, eccen, mvelpp, lambm0, &
+                            obliqr, decln, eccf)
       if (icepack_warnings_aborted(subname)) return
-
       coszen = sin(tlat)*sin(decln) &
              + cos(tlat)*cos(decln) &
              *cos((sec/secday-p5)*c2*pi + tlon) !cos(hour angle)
-
-#ifdef CESMCOUPLED
-      endif
 #endif
 
       end subroutine compute_coszen
 
 !===============================================================================
 
-#ifndef CESMCOUPLED
-SUBROUTINE shr_orb_params( iyear_AD , eccen , obliq , mvelp    , &
+SUBROUTINE icepack_orb_params( iyear_AD , eccen , obliq , mvelp    , &
                            obliqr   , lambm0, mvelpp, log_print)
 
 !-------------------------------------------------------------------------------
@@ -445,13 +444,13 @@ SUBROUTINE shr_orb_params( iyear_AD , eccen , obliq , mvelp    , &
    real   (dbl_kind) :: eccen3  ! eccentricity cubed
    real   (dbl_kind) :: degrad  ! degrees to rad conversion
    integer (int_kind), parameter :: s_loglev    = 0
-   character(len=*),parameter :: subname='(shr_orb_params)'
+   character(len=*),parameter :: subname='(icepack_orb_params)'
 
    !-------------------------- Formats -----------------------------------------
-   character(len=*),parameter :: F00 = "('(shr_orb_params) ',4a)"
-   character(len=*),parameter :: F01 = "('(shr_orb_params) ',a,i9)"
-   character(len=*),parameter :: F02 = "('(shr_orb_params) ',a,f6.3)"
-   character(len=*),parameter :: F03 = "('(shr_orb_params) ',a,es14.6)"
+   character(len=*),parameter :: F00 = "('(icepack_orb_params) ',4a)"
+   character(len=*),parameter :: F01 = "('(icepack_orb_params) ',a,i9)"
+   character(len=*),parameter :: F02 = "('(icepack_orb_params) ',a,f6.3)"
+   character(len=*),parameter :: F03 = "('(icepack_orb_params) ',a,es14.6)"
 
    !----------------------------------------------------------------------------
    ! radinp and algorithms below will need a degree to radian conversion factor
@@ -692,11 +691,11 @@ SUBROUTINE shr_orb_params( iyear_AD , eccen , obliq , mvelp    , &
      call icepack_warnings_add(warnstr)
    end if
 
-END SUBROUTINE shr_orb_params
+END SUBROUTINE icepack_orb_params
 
 !===============================================================================
 
-SUBROUTINE shr_orb_decl(calday ,eccen ,mvelpp ,lambm0 ,obliqr ,delta ,eccf)
+SUBROUTINE icepack_orb_decl(calday ,eccen ,mvelpp ,lambm0 ,obliqr ,delta ,eccf)
 
 !-------------------------------------------------------------------------------
 !
@@ -732,7 +731,7 @@ SUBROUTINE shr_orb_decl(calday ,eccen ,mvelpp ,lambm0 ,obliqr ,delta ,eccf)
    real   (dbl_kind) ::   invrho ! Inverse normalized sun/earth distance
    real   (dbl_kind) ::   sinl   ! Sine of lmm
 
-   character(len=*),parameter :: subname='(shr_orb_decl)'
+   character(len=*),parameter :: subname='(icepack_orb_decl)'
 
    ! Compute eccentricity factor and solar declination using
    ! day value where a round day (such as 213.0) refers to 0z at
@@ -776,8 +775,7 @@ SUBROUTINE shr_orb_decl(calday ,eccen ,mvelpp ,lambm0 ,obliqr ,delta ,eccf)
 
    return
 
-END SUBROUTINE shr_orb_decl
-#endif
+END SUBROUTINE icepack_orb_decl
 
 !=======================================================================
 

--- a/columnphysics/icepack_parameters.F90
+++ b/columnphysics/icepack_parameters.F90
@@ -132,6 +132,7 @@
          dSin0_frazil = c3            ,&! bulk salinity reduction of newly formed frazil
          dts_b     = 50._dbl_kind     ,&! zsalinity timestep
          ustar_min = 0.005_dbl_kind   ,&! minimum friction velocity for ocean heat flux (m/s)
+         hi_min    = p01              ,&! minimum ice thickness allowed (m) for thermo
          ! mushy thermo
          a_rapid_mode      =  0.5e-3_dbl_kind,&! channel radius for rapid drainage mode (m)
          Rac_rapid_mode    =    10.0_dbl_kind,&! critical Rayleigh number
@@ -457,7 +458,7 @@
          awtvdr_in, awtidr_in, awtvdf_in, awtidf_in, &
          qqqice_in, TTTice_in, qqqocn_in, TTTocn_in, &
          ktherm_in, conduct_in, fbot_xfer_type_in, calc_Tsfc_in, dts_b_in, &
-         update_ocn_f_in, ustar_min_in, a_rapid_mode_in, &
+         update_ocn_f_in, ustar_min_in, hi_min_in, a_rapid_mode_in, &
          Rac_rapid_mode_in, aspect_rapid_mode_in, &
          dSdt_slow_mode_in, phi_c_slow_mode_in, &
          phi_i_mushy_in, shortwave_in, albedo_type_in, albsnowi_in, &
@@ -575,6 +576,7 @@
 
       real (kind=dbl_kind), intent(in), optional :: &
          dts_b_in,   &      ! zsalinity timestep
+         hi_min_in,  &      ! minimum ice thickness allowed (m) for thermo
          ustar_min_in       ! minimum friction velocity for ice-ocean heat flux
 
       ! mushy thermo
@@ -929,6 +931,7 @@
       if (present(update_ocn_f_in)      ) update_ocn_f     = update_ocn_f_in
       if (present(dts_b_in)             ) dts_b            = dts_b_in
       if (present(ustar_min_in)         ) ustar_min        = ustar_min_in
+      if (present(hi_min_in)            ) hi_min           = hi_min_in
       if (present(a_rapid_mode_in)      ) a_rapid_mode     = a_rapid_mode_in
       if (present(Rac_rapid_mode_in)    ) Rac_rapid_mode   = Rac_rapid_mode_in
       if (present(aspect_rapid_mode_in) ) aspect_rapid_mode= aspect_rapid_mode_in
@@ -1171,7 +1174,7 @@
          min_bgc_out, dSin0_frazil_out, hi_ssl_out, hs_ssl_out, &
          awtvdr_out, awtidr_out, awtvdf_out, awtidf_out, &
          qqqice_out, TTTice_out, qqqocn_out, TTTocn_out, update_ocn_f_out, &
-         Lfresh_out, cprho_out, Cp_out, ustar_min_out, a_rapid_mode_out, &
+         Lfresh_out, cprho_out, Cp_out, ustar_min_out, hi_min_out, a_rapid_mode_out, &
          ktherm_out, conduct_out, fbot_xfer_type_out, calc_Tsfc_out, dts_b_out, &
          Rac_rapid_mode_out, aspect_rapid_mode_out, dSdt_slow_mode_out, &
          phi_c_slow_mode_out, phi_i_mushy_out, shortwave_out, &
@@ -1299,6 +1302,7 @@
 
       real (kind=dbl_kind), intent(out), optional :: &
          dts_b_out,   &      ! zsalinity timestep
+         hi_min_out,  &      ! minimum ice thickness allowed (m) for thermo
          ustar_min_out       ! minimum friction velocity for ice-ocean heat flux
 
       ! mushy thermo
@@ -1685,6 +1689,7 @@
       if (present(update_ocn_f_out)      ) update_ocn_f_out = update_ocn_f
       if (present(dts_b_out)             ) dts_b_out        = dts_b
       if (present(ustar_min_out)         ) ustar_min_out    = ustar_min
+      if (present(hi_min_out)            ) hi_min_out       = hi_min
       if (present(a_rapid_mode_out)      ) a_rapid_mode_out = a_rapid_mode
       if (present(Rac_rapid_mode_out)    ) Rac_rapid_mode_out = Rac_rapid_mode
       if (present(aspect_rapid_mode_out) ) aspect_rapid_mode_out = aspect_rapid_mode
@@ -1895,6 +1900,7 @@
         write(iounit,*) "  update_ocn_f      = ", update_ocn_f
         write(iounit,*) "  dts_b             = ", dts_b
         write(iounit,*) "  ustar_min         = ", ustar_min
+        write(iounit,*) "  hi_min            = ", hi_min
         write(iounit,*) "  a_rapid_mode      = ", a_rapid_mode
         write(iounit,*) "  Rac_rapid_mode    = ", Rac_rapid_mode
         write(iounit,*) "  aspect_rapid_mode = ", aspect_rapid_mode

--- a/columnphysics/icepack_shortwave.F90
+++ b/columnphysics/icepack_shortwave.F90
@@ -3921,7 +3921,7 @@
          if (.not.present(days_per_year) .or. &
              .not.present(nextsw_cday) .or. &
              .not.present(calendar_type)) then
-            call icepack_warnings_add(subname//' ERROR: CESMCOUPLE CPP on, need more calendar data')
+            call icepack_warnings_add(subname//' ERROR: CESMCOUPLED CPP on, need more calendar data')
             call icepack_warnings_setabort(.true.,__FILE__,__LINE__)
             return
          endif

--- a/columnphysics/icepack_therm_bl99.F90
+++ b/columnphysics/icepack_therm_bl99.F90
@@ -13,9 +13,6 @@
 
       use icepack_kinds
       use icepack_parameters, only: c0, c1, c2, p1, p5, puny
-#ifdef CESMCOUPLED
-      use icepack_parameters, only: p01
-#endif
       use icepack_parameters, only: rhoi, rhos, hs_min, cp_ice, cp_ocn, depressT, Lfresh, ksno, kice
       use icepack_parameters, only: conduct, calc_Tsfc, solve_zsal
       use icepack_parameters, only: sw_redist, sw_frac, sw_dtemp

--- a/columnphysics/icepack_therm_itd.F90
+++ b/columnphysics/icepack_therm_itd.F90
@@ -30,7 +30,7 @@
 #else
       use icepack_parameters, only: kitd, ktherm
 #endif
-      use icepack_parameters, only: z_tracers, solve_zsal, hfrazilmin
+      use icepack_parameters, only: z_tracers, solve_zsal, hfrazilmin, hi_min
 
       use icepack_tracers, only: ntrcr, nbtrcr
       use icepack_tracers, only: nt_qice, nt_qsno, nt_fbri, nt_sice
@@ -55,7 +55,6 @@
       use icepack_itd, only: column_sum, column_conservation_check
       use icepack_isotope, only: isoice_alpha, isotope_frac_method
       use icepack_mushy_physics, only: liquidus_temperature_mush, enthalpy_mush
-      use icepack_therm_shared, only: hi_min
       use icepack_zbgc, only: add_new_ice_bgc
       use icepack_zbgc, only: lateral_melt_bgc
 
@@ -113,7 +112,7 @@
          nslyr   , & ! number of snow layers
          ntrcr       ! number of tracers in use
 
-      real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
+      real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
          hin_max      ! category boundaries (m)
 
       integer (kind=int_kind), dimension (:), intent(in) :: &
@@ -210,8 +209,6 @@
       !-----------------------------------------------------------------
       ! Initialize
       !-----------------------------------------------------------------
-
-      hin_max(ncat) = 999.9_dbl_kind ! arbitrary big number
 
       do n = 1, ncat
          donor(n) = 0
@@ -2006,7 +2003,7 @@
       logical (kind=log_kind), intent(in) :: &
          update_ocn_f     ! if true, update fresh water and salt fluxes
 
-      real (kind=dbl_kind), dimension(0:ncat), intent(inout) :: &
+      real (kind=dbl_kind), dimension(0:ncat), intent(in) :: &
          hin_max      ! category boundaries (m)
 
       real (kind=dbl_kind), intent(in) :: &

--- a/columnphysics/icepack_therm_shared.F90
+++ b/columnphysics/icepack_therm_shared.F90
@@ -52,9 +52,6 @@
       logical (kind=log_kind), public :: &
          l_brine         ! if true, treat brine pocket effects
 
-      real (kind=dbl_kind), public :: &
-         hi_min          ! minimum ice thickness allowed (m)
-
 !=======================================================================
 
       contains

--- a/columnphysics/icepack_therm_vertical.F90
+++ b/columnphysics/icepack_therm_vertical.F90
@@ -31,7 +31,6 @@
       use icepack_parameters, only: ustar_min, fbot_xfer_type, formdrag, calc_strair
       use icepack_parameters, only: rfracmin, rfracmax, dpscale, frzpnd, snwgrain, snwlvlfac
       use icepack_parameters, only: phi_i_mushy, floeshape, floediam, use_smliq_pnd, snwredist
-
       use icepack_tracers, only: tr_iage, tr_FY, tr_aero, tr_pond, tr_fsd, tr_iso
 #ifdef UNDEPRECATE_CESMPONDS
       use icepack_tracers, only: tr_pond_cesm, tr_pond_lvl, tr_pond_topo
@@ -42,7 +41,6 @@
 
       use icepack_therm_shared, only: ferrmax, l_brine
       use icepack_therm_shared, only: calculate_tin_from_qin, Tmin
-      use icepack_therm_shared, only: hi_min
       use icepack_therm_shared, only: adjust_enthalpy
       use icepack_therm_bl99,   only: temperature_changes
 #ifdef UNDEPRECATE_0LAYER
@@ -463,14 +461,12 @@
       ! If prescribed ice, set hi back to old values
       !-----------------------------------------------------------------
 
-#ifdef CESMCOUPLED
       if (present(prescribed_ice)) then
           if (prescribed_ice) then
             hin    = worki
             fhocnn = c0             ! for diagnostics
           endif
       endif
-#endif
 
       !-----------------------------------------------------------------
       ! Compute fluxes of water and salt from ice to ocean.
@@ -2924,7 +2920,6 @@
             if (tr_pond_cesm) then
                rfrac = rfracmin + (rfracmax-rfracmin) * aicen(n)
                call compute_ponds_cesm(dt=dt,           &
-                                       hi_min=hi_min,   &
                                        rfrac=rfrac,     &
                                        meltt=melttn(n), &
                                        melts=meltsn(n), &
@@ -2943,11 +2938,6 @@
 #endif
                rfrac = rfracmin + (rfracmax-rfracmin) * aicen(n)
                call compute_ponds_lvl (dt=dt,            &
-                                       nilyr=nilyr,      &
-                                       ktherm=ktherm,    &
-                                       hi_min=hi_min,    &
-                                       dpscale=dpscale,  &
-                                       frzpnd=frzpnd,    &
                                        rfrac=rfrac,      &
                                        meltt=melttn (n), &
                                        melts=meltsn (n), &

--- a/configuration/driver/icedrv_init.F90
+++ b/configuration/driver/icedrv_init.F90
@@ -88,7 +88,7 @@
       character (len=char_len), dimension(4) :: nx_names_default
 
       real (kind=dbl_kind) :: ustar_min, albicev, albicei, albsnowv, albsnowi, &
-         ahmax, R_ice, R_pnd, R_snw, dT_mlt, rsnw_mlt, ksno, &
+         ahmax, R_ice, R_pnd, R_snw, dT_mlt, rsnw_mlt, ksno, hi_min, &
          mu_rdg, hs0, dpscale, rfracmin, rfracmax, pndaspect, hs1, hp1, &
          a_rapid_mode, Rac_rapid_mode, aspect_rapid_mode, dSdt_slow_mode, &
          phi_c_slow_mode, phi_i_mushy, kalg, emissivity, floediam, hfrazilmin, &
@@ -177,7 +177,7 @@
         update_ocn_f,    l_mpond_fresh,   ustar_min,       &
         fbot_xfer_type,  oceanmixed_ice,  emissivity,      &
         formdrag,        highfreq,        natmiter,        &
-        atmiter_conv,    calc_dragio,                      &
+        atmiter_conv,    calc_dragio,     hi_min,          &
         tfrz_option,     default_season,  wave_spec_type,  &
         precip_units,    fyear_init,      ycycle,          &
         atm_data_type,   ocn_data_type,   bgc_data_type,   &
@@ -206,7 +206,7 @@
 
       call icepack_query_parameters(ustar_min_out=ustar_min, Cf_out=Cf, &
            albicev_out=albicev, albicei_out=albicei, ksno_out = ksno,   &
-           albsnowv_out=albsnowv, albsnowi_out=albsnowi, &
+           albsnowv_out=albsnowv, albsnowi_out=albsnowi, hi_min_out=hi_min, &
            natmiter_out=natmiter, ahmax_out=ahmax, shortwave_out=shortwave, &
            atmiter_conv_out = atmiter_conv, calc_dragio_out=calc_dragio, &
            albedo_type_out=albedo_type, R_ice_out=R_ice, R_pnd_out=R_pnd, &
@@ -790,6 +790,7 @@
          write(nu_diag,1030) ' wave_spec_type            = ', trim(wave_spec_type)
          write(nu_diag,1010) ' l_mpond_fresh             = ', l_mpond_fresh
          write(nu_diag,1005) ' ustar_min                 = ', ustar_min
+         write(nu_diag,1005) ' hi_min                    = ', hi_min
          write(nu_diag,1030) ' fbot_xfer_type            = ', trim(fbot_xfer_type)
          write(nu_diag,1010) ' oceanmixed_ice            = ', oceanmixed_ice
          write(nu_diag,1030) ' tfrz_option               = ', trim(tfrz_option)
@@ -955,7 +956,7 @@
 
       call icepack_init_parameters(ustar_min_in=ustar_min, Cf_in=Cf, &
            albicev_in=albicev, albicei_in=albicei, ksno_in=ksno, &
-           albsnowv_in=albsnowv, albsnowi_in=albsnowi, &
+           albsnowv_in=albsnowv, albsnowi_in=albsnowi, hi_min_in=hi_min, &
            natmiter_in=natmiter, ahmax_in=ahmax, shortwave_in=shortwave, &
            atmiter_conv_in = atmiter_conv, calc_dragio_in=calc_dragio, &
            albedo_type_in=albedo_type, R_ice_in=R_ice, R_pnd_in=R_pnd, &

--- a/configuration/scripts/icepack_in
+++ b/configuration/scripts/icepack_in
@@ -104,6 +104,7 @@
     natmiter        = 5
     atmiter_conv    = 0.0d0
     ustar_min       = 0.0005
+    hi_min          = 0.01
     calc_dragio     = .false.
     emissivity      = 0.985
     fbot_xfer_type  = 'constant'

--- a/configuration/scripts/options/set_nml.thermo1
+++ b/configuration/scripts/options/set_nml.thermo1
@@ -1,6 +1,7 @@
 kcatbound = 0
 kitd    = 0
 ktherm  = 1
+hi_min  = 0.1
 sw_redist         = .true.
 sw_frac           = 0.9d0
 sw_dtemp          = 0.02d0

--- a/doc/source/icepack_index.rst
+++ b/doc/source/icepack_index.rst
@@ -205,7 +205,7 @@ either Celsius or Kelvin units).
    "HDO_ocn", "concentration of HDO isotope in ocean", "kg/kg"
    "heat_capacity", "DEPRECATED", ""
    "hfrazilmin", "minimum thickness of new frazil ice", "0.05 m"
-   "hi_min", "minimum ice thickness for thinnest ice category", "0.01 m"
+   "hi_min", "minimum ice thickness for thinnest ice category", "m"
    "hi_ssl", "ice surface scattering layer thickness", "0.05 m"
    "hicen", "ice thickness in category n", "m"
    "highfreq", ":math:`\bullet` high-frequency atmo coupling", "F"

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -354,6 +354,7 @@ forcing_nml
    "``formdrag``", "logical", "calculate form drag", "``.false.``"
    "``fyear_init``", "integer", "first year of atmospheric forcing data", "1998"
    "``highfreq``", "logical", "high-frequency atmo coupling", "``.false.``"
+   "``hi_min``", "real", "! minimum ice thickness allowed for thermo in m", "0.01"
    "``ice_data_file``", "string", "file containing ice opening, closing data", "' '"
    "``l_mpond_fresh``", "``.false.``", "release pond water immediately to ocean", "``.false.``"
    "", "``true``", "retain (topo) pond water until ponds drain", ""

--- a/doc/source/user_guide/ug_case_settings.rst
+++ b/doc/source/user_guide/ug_case_settings.rst
@@ -354,7 +354,7 @@ forcing_nml
    "``formdrag``", "logical", "calculate form drag", "``.false.``"
    "``fyear_init``", "integer", "first year of atmospheric forcing data", "1998"
    "``highfreq``", "logical", "high-frequency atmo coupling", "``.false.``"
-   "``hi_min``", "real", "! minimum ice thickness allowed for thermo in m", "0.01"
+   "``hi_min``", "real", "minimum ice thickness allowed for thermo in m", "0.01"
    "``ice_data_file``", "string", "file containing ice opening, closing data", "' '"
    "``l_mpond_fresh``", "``.false.``", "release pond water immediately to ocean", "``.false.``"
    "", "``true``", "retain (topo) pond water until ponds drain", ""


### PR DESCRIPTION
## PR checklist
- [X] Short (1 sentence) summary of your PR: 
  Minor updates consistent with E3SM columnphysics modifications
- [X] Developer(s): 
    apcraig
- [X] Suggest PR reviewers from list in the column to the right.
- [X] Please copy the PR test results link or provide a summary of testing completed below.
    bit-for-bit Icepack test suite on 3 compilers on cheyenne
- How much do the PR code changes differ from the unmodified code? 
    - [X] bit for bit (but need to be careful due to change in how hi_min is set)
    - [ ] different at roundoff level
    - [ ] more substantial 
- Does this PR create or have dependencies on CICE or any other models?
    - [ ] Yes
    - [X] No
- Does this PR add any new test cases?
    - [ ] Yes
    - [X] No
- Is the documentation being updated? ("Documentation" includes information on the wiki or in the .rst files from doc/source/, which are used to create the online technical docs at https://readthedocs.org/projects/cice-consortium-cice/.)
    - [X] Yes
    - [ ] No, does the documentation need to be updated at a later time?
        - [ ] Yes
        - [ ] No 
- [X] Please provide any additional information or relevant details below:

- Migrate hi_min to namelist+parameters and refactor implementation.  In the current implementation, hi_min is set by namelist.  Historically, this has been hardcoded in the model with a the value set to .01 except when kcatbound=0 and kitd/=1 where it was set to 0.1 (except if the CESMCOUPLED CPP is turned on).  Users should be aware that it now needs to be set in namelist if the default value, 0.01 should be changed.  In testing, when kcatbound=0 and kitd/=1, we set hi_min to 0.1 to reproduce prior results bit-for-bit and confirm this works.
- Reduce CESMCOUPLED CPP use, now just for orbital stuff, punch list 23
- Modify initialization of hin_max, punch list 28
- Fix possible divide by zero, punch list 65
- Rename icepack shr_orb_params and shr_orb_decl to icepack_orb_params, icepack_orb_decl
- Cleanup argument list for compute_ponds_lvl, compute_ponds_cesm
