### PR TITLE
Corrects negative silicate values in sea ice

### DIFF
--- a/columnphysics/icepack_algae.F90
+++ b/columnphysics/icepack_algae.F90
@@ -1860,13 +1860,10 @@
           U_Nit(k) = U_Nit_f(k)*U_Nit_tot
           U_Sil(k) = U_Sil_f(k)*U_Sil_tot
           U_Fe(k)  = U_Fe_f(k)*U_Fe_tot
-
-          if (n_fed == 0) then
-             if (R_Si2N(k) > c0) then
-                grow_N(k) = min(U_Sil(k)/R_Si2N(k),U_Nit(k) + U_Am(k), U_Fe(k)/R_Fe2N(k))
-             else
-                grow_N(k) = min(U_Nit(k) + U_Am(k),U_Fe(k)/R_Fe2N(k))
-             endif
+          if (R_Si2N(k) > c0) then
+             grow_N(k) = min(U_Sil(k)/R_Si2N(k),U_Nit(k) + U_Am(k), U_Fe(k)/R_Fe2N(k))
+          else
+             grow_N(k) = min(U_Nit(k) + U_Am(k),U_Fe(k)/R_Fe2N(k))
           endif
 
           fr_Am(k) = c0


### PR DESCRIPTION
Fixes a bug introduced in Icepack V1.5.0.

Silicate limitation should not be wrapped in an if statement for iron tracers.

nonBFB with active BGC.  BFB for all else.

See Issue https://github.com/E3SM-Project/E3SM/issues/7127

Tested in a fully-coupled biogeochemistry simulation. Simulation page and comparisons with a control run are here:
https://acme-climate.atlassian.net/wiki/spaces/HESF/pages/5121212417/20250314.v3.LR.CBGC.FrazilEcosys.noSpinup.pm-cpu

The ice.log files with Icepack v1.5.0 with active BGC has warning messages after about 4 years indicating negative silicate. This is because silicate limitation is not implemented correctly. The fix removes an incorrect if block around the silicate limitation functions. With this fix, no warning messages were observed over the simulation (~36 years).